### PR TITLE
optimization and consistent column name

### DIFF
--- a/R/clean_jcdf.R
+++ b/R/clean_jcdf.R
@@ -7,15 +7,20 @@
 #' @concept getdata
 #'
 
-clean_census <- function(path) {
+clean_jcdf <- function(path) {
 
-  pref <- NA
+  pref_raw <- sf::st_read(path)
+  pref_raw <- sf::st_make_valid(pref_raw)
 
   # filter out water surfaces and extraneous port data
+  pref <- NA
   pref <- path %>%
     dplyr::filter(path$KIHON1 != "0000" & path$HCODE != 8154, )  %>%
-    dplyr::group_by(PREF, CITY, KIHON1, CITY_NAME, S_NAME) %>%
-    dplyr::summarize(geometry = sf::st_union(geometry), JINKO = sum(JINKO)) %>%
+    dplyr::group_by(PREF, CITY, KIHON1, CITY_NAME) %>%
+    # make smallest geopolitical subdivision to level 2
+    dplyr::slice(1) %>%
+    dplyr::summarize(geometry = sf::st_union(geometry), JINKO = sum(JINKO), S_NAME) %>%
+    # make 5 digit municipality code
     dplyr::mutate(code = 1000*as.numeric(PREF) + as.numeric(CITY)) %>%
     dplyr::select(code, CITY_NAME, S_NAME, KIHON1, JINKO, geometry)
 


### PR DESCRIPTION
1. Optimized the data wrangling part by using tidyverse instead of BaseR. I think this will make it faster.
2. I think we shouldn't change the column name from original Japanese census data, since we want our functions applicable for Japanese census analysis for other researchers. Although they are not informative in English, people who use Japanese census data should check the original codebook (from e-Stat) before they work on it. If we decide to change it, we can easily reflect our change of codes if we decide now, not in the end.