### PR TITLE
fix mun_boundary/ gun_boundary 

### DIFF
--- a/R/template/03_visualization.R
+++ b/R/template/03_visualization.R
@@ -138,10 +138,10 @@ sim_smc_pref_1 <- redist::match_numbers(sim_smc_pref_1,
                                         col = "pop_overlap")
 
 # Gun/Municipality/Koiki-renkei boundaries
-mun_boundary <- pref_0 %>%
+mun_boundary <- pref %>%
   group_by(code) %>%
   summarise(geometry = sf::st_union(geometry))
-gun_boundary <- pref_0 %>%
+gun_boundary <- pref %>%
   filter(gun_code >= (pref_map_0$code[1]%/%1000)* 1000 + 300) %>%
   group_by(gun_code) %>%
   summarise(geometry = sf::st_union(geometry))


### PR DESCRIPTION
I spotted an error that causes the municipality boundary and the gun boundary to be the same even in cases where they are not the same. (i.e. Currently, when a 郡 is made up of multiple municipalities, the boundaries for each municipality do not appear on the map for the simulated plans)
I have fixed this error by changing two lines of codes in 03_visualization.R and I would appreciate it if you could merge this into main and to make this change for the 3 prefectures you've worked on so far. Thanks.

@shomiyazaki2000

